### PR TITLE
Check for fsc and fsharpc in build.bash

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -1,7 +1,16 @@
 #!/bin/bash
 
-# by default use fsc
-FSC=${FSC:-fsc}
+# by default use fsc, or fsharpc
+if [ -z "$FSC" ]; then
+    if command -v fsc >/dev/null 2>&1; then
+        FSC=fsc
+    elif command -v fsharpc >/dev/null 2>&1; then
+        FSC=fsharpc
+    else
+        echo "No FSharp compiler found!"
+        exit 1
+    fi
+fi
 
 # exit on error and don't allow the use of unset variables
 set -o errexit

--- a/gen-bindings.bash
+++ b/gen-bindings.bash
@@ -1,12 +1,21 @@
 #!/bin/bash
 
+# by default use fsc, or fsharpc
+if [ -z "$FSC" ]; then
+    if command -v fsc >/dev/null 2>&1; then
+        FSC=fsc
+    elif command -v fsharpc >/dev/null 2>&1; then
+        FSC=fsharpc
+    else
+        echo "No FSharp compiler found!"
+        exit 1
+    fi
+fi
+
 # exit on error and don't allow the use of unset variables
 set -o errexit
 set -o nounset
 set -x
-
-# by default use fsc
-FSC=${FSC:-fsc}
 
 # build and run special purpose tool for generating LLVM C bindings
 fslex --unicode bindinggen/Lexer.fsl


### PR DESCRIPTION
Default FSharp install on linux installs the compiler and interactive
as fsharpc and fsharpi, not fsc and fsi as on other platforms. This
adds a check to see if FSC is defined and if not checks for fsc and
fsharpc. If no compiler is found/defined it errors and exits the
build.
